### PR TITLE
fix(deploy): install devDeps during Render build (--include=dev)

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -9,7 +9,9 @@ services:
     runtime: node
     plan: starter # free tier (512MB) often OOMs the Next build; starter is safer
     branch: dev/ver-1 # change to your deploy branch (e.g. Portfolio_AD) if needed
-    buildCommand: npm ci && npm run build
+    # NODE_ENV=production makes `npm ci` skip devDeps; --include=dev pulls back the
+    # build-only tools (@tailwindcss/postcss, tailwindcss, typescript) the build needs.
+    buildCommand: npm ci --include=dev && npm run build
     startCommand: npm run start # binds to $PORT via the start script
     autoDeploy: true
     envVars:


### PR DESCRIPTION
NODE_ENV=production made npm ci skip devDependencies, so the build-only @tailwindcss/postcss plugin was missing and 'next build' failed.