### PR TITLE
feat(hero): 3D orbiting SSD hero redesign

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,49 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
 @AGENTS.md
+
+## Commands
+
+```bash
+npm run dev      # dev server (Turbopack) → http://localhost:3000
+npm run build    # production build
+npm run start    # serve the production build, binds to $PORT (default 3000)
+npm run lint     # eslint (eslint.config.mjs)
+npm run lint -- app/(site)/page.tsx   # lint a single file/path
+```
+
+There is **no test suite** in this repo.
+
+Node 22 is pinned (`.node-version`). The `@/*` TypeScript path alias maps to the repo root.
+
+## Big picture
+
+A single-page personal portfolio **ported from a [Claude Design](https://claude.ai/design) prototype** into a production Next.js 16 App Router app (React 19, Tailwind v4, Framer Motion). Two standalone browser tools (a PDF editor and a code formatter) ride along in the same app.
+
+Because of the port, **large parts of the codebase are vendored verbatim** from the prototype and should not be "cleaned up" casually — they are eslint-ignored or have relaxed lint rules on purpose (see `eslint.config.mjs`): `public/bg3d.js`, `public/image-slot.js`, `public/pdf-editor/**`, and the `components/pdf-editor/**` + `components/code-formatter/**` modules (faithful single-bundle ports preserving original shared-scope structure).
+
+### Route groups = isolated apps
+
+`app/` uses two route groups, **each with its own root `<html>/<body>` layout** so their CSS/design tokens never leak into each other (Next loads each segment's CSS only for that segment):
+
+- **`app/(site)/`** — the portfolio. `layout.tsx` is the design shell (fonts, pre-paint theme script, `ThemeProvider`, `Atmosphere`, `SiteChrome`, `Footer`, vendored scripts). `page.tsx` composes sections in order: Hero → Marquee → AppStore → Work → About → Experience → Contact. `app/globals.css` is the full design system (OKLCH tokens, 3 palettes × light/dark) and loads **only** here.
+- **`app/(tool)/`** — full-screen tools (`pdf-editor`, `code-formatter`), each with its own minimal layout + fonts. The tool pages `dynamic(..., { ssr: false })`-import heavy client-only components, since they rely on `window`/`document`/canvas/clipboard and must never run during SSR/prerender.
+
+### Content is data, not markup
+
+All portfolio copy lives in `lib/content.ts`. Section components map over it — **edit copy there, not in component JSX**. Prototype relative links (`apps/x.html`) are stored as absolute `/apps/x.html` paths resolving against `public/`.
+
+### Theming (SSR-safe, no flash)
+
+`components/ThemeProvider.tsx` owns theme / palette / accent hue / display font / film grain / 3D backdrop, persisted to `localStorage` (`ps_portfolio`). The flash-free pattern matters: SSR and first client render use the authored `DEFAULTS`; a **pre-paint inline `<script>` (`themeInitScript`, exported from the same file)** applies saved settings to `<html>`/`<body>` before React hydrates; the provider then reconciles `localStorage` in a mount effect. It also drives `window.BG3D` (the verbatim `public/bg3d.js` particle backdrop). If you change how settings are applied, update **both** `apply()` and `themeInitScript` to keep them in sync.
+
+### PDF editor engine
+
+`components/pdf-editor/lib/engine.ts` is the real engine: `pdfjs-dist` renders/extracts, `pdf-lib` builds/edits/flattens, and `crypto.ts` (qpdf-wasm) layers encryption. The pdf.js worker is served from `/pdf-editor/pdf.worker.min.mjs` (a vendored asset, not bundled).
+
+### Other notable wiring
+
+- `next.config.ts` rewrites `/.image-slots.state.json` → `/api/image-slots` (an empty sidecar) so the vendored `<image-slot>` web component doesn't 404. `<image-slot>` is a custom JSX element typed in `types/custom-elements.d.ts`; its drops only persist in the design runtime — placeholders here are intentional (see README TODO for replacing them with real images).
+- **Deploy:** `render.yaml` deploys as a **Node web service, not a static site** (SSR + the `/api/image-slots` route require `next start`). The build runs `npm ci --include=dev` because `NODE_ENV=production` would otherwise drop the build-only devDeps (tailwind/postcss/typescript). Deploy branch is `dev/ver-1`.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 A single-page personal portfolio (Staff Engineer @ SanDisk), ported from a
 [Claude Design](https://claude.ai/design) prototype ("Portfolio – Photo Hero")
-into a production Next.js app.
+into a production Next.js app. It also bundles two standalone browser tools —
+a PDF editor and a code formatter — under their own routes.
 
 **Stack:** Next.js (App Router) · TypeScript · Tailwind CSS v4 · Framer Motion.
 
@@ -17,23 +18,39 @@ npm run start    # serve the production build
 
 ## Structure
 
+The app uses two App Router **route groups**, each with its own root
+`<html>`/`<body>` layout so their CSS and design tokens stay isolated:
+`(site)` is the portfolio, `(tool)` holds standalone full-screen browser tools.
+
 ```
 app/
-  layout.tsx       root shell: fonts, theme init, Atmosphere, Nav/Portal, Footer, vendored scripts
-  page.tsx         section composition (Hero → Marquee → AppStore → Work → About → Experience → Contact)
-  globals.css      the design system, ported verbatim from the prototype (OKLCH tokens, 3 palettes × light/dark)
+  (site)/
+    layout.tsx     portfolio shell: fonts, pre-paint theme init, Atmosphere, SiteChrome (Nav/Portal), Footer, vendored scripts
+    page.tsx       section composition (Hero → Marquee → AppStore → Work → About → Experience → Contact)
+  (tool)/
+    pdf-editor/    full-screen PDF editor — annotate, reorder, split, merge, protect (client-only)
+    code-formatter/ full-screen code/data formatter (client-only)
+  globals.css      the design system, ported verbatim from the prototype (OKLCH tokens, 3 palettes × light/dark); loaded only by (site)
   api/image-slots  empty <image-slot> sidecar (served at /.image-slots.state.json via a rewrite)
 components/
   ThemeProvider    theme / palette / accent / grain / 3D-backdrop state + localStorage; drives window.BG3D
   Reveal           Framer Motion scroll-reveal wrapper (replaces the prototype's .reveal + IntersectionObserver)
+  SiteChrome       fixed chrome owning Nav + Portal modal open state
   Nav / Portal / Footer / BrandDot / Atmosphere
   sections/        Hero, Marquee, AppStore, Work, About, Experience, Contact
-lib/content.ts     all copy (edit content here, not in markup)
+  pdf-editor/      PDF editor UI + engine (pdfjs-dist render, pdf-lib edit, qpdf-wasm encrypt) — verbatim port
+  code-formatter/  code formatter UI + engine — verbatim port
+lib/content.ts     all portfolio copy (edit content here, not in markup)
 public/
   bg3d.js          3D particle backdrop — ported verbatim from the prototype
   image-slot.js    drag-drop image placeholder web component — ported verbatim
   apps/            App Store sub-pages + gradient icons
+  pdf-editor/      vendored PDF runtime assets (pdf.js worker, qpdf-wasm glue)
 ```
+
+The two tools live in `app/(tool)/` and are loaded with `dynamic(..., { ssr:
+false })` because they rely on browser APIs (`window`/`document`/canvas/
+clipboard) and must not run during SSR/prerender.
 
 ## Theming
 

--- a/app/(site)/layout.tsx
+++ b/app/(site)/layout.tsx
@@ -50,6 +50,7 @@ export default function RootLayout({ children }: Readonly<{ children: React.Reac
         {/* Bespoke prototype scripts, ported verbatim. */}
         <Script src="/image-slot.js" strategy="afterInteractive" />
         <Script src="/bg3d.js" strategy="afterInteractive" />
+        <Script src="/hero-orbit.js" strategy="afterInteractive" />
       </body>
     </html>
   );

--- a/app/(site)/page.tsx
+++ b/app/(site)/page.tsx
@@ -1,5 +1,4 @@
 import { Hero } from "@/components/sections/Hero";
-import { Marquee } from "@/components/sections/Marquee";
 import { AppStore } from "@/components/sections/AppStore";
 import { Work } from "@/components/sections/Work";
 import { About } from "@/components/sections/About";
@@ -10,7 +9,6 @@ export default function Home() {
   return (
     <main id="top">
       <Hero />
-      <Marquee />
       <AppStore />
       <Work />
       <About />

--- a/app/globals.css
+++ b/app/globals.css
@@ -31,6 +31,13 @@
   --accent-h: 155;            /* authored default (emerald); swappable via settings */
   --accent-c: 0.13;
   --ease: cubic-bezier(0.22, 1, 0.36, 1);
+
+  /* hero orbit — satellite group colors */
+  --g-lang: #E0A93C;   /* language */
+  --g-fw:   #2FBFB0;   /* frameworks */
+  --g-inf:  #F0738A;   /* inference infra */
+  --g-ml:   #9A82F5;   /* RAG & training */
+  --g-std:  #5B9DF0;   /* storage standards */
 }
 
 /* ---------- Palettes × theme ---------- */
@@ -293,6 +300,16 @@ main, .footer, .nav { position: relative; z-index: 1; }
 .marquee__dot { color: var(--accent) !important; font-style: normal !important; font-size: 16px !important; }
 @keyframes marquee { to { transform: translateX(-50%); } }
 @media (prefers-reduced-motion: reduce) { .marquee__track { animation: none; } }
+/* marquee pinned to the bottom of the hero, full-bleed */
+.marquee--hero {
+  position: absolute; left: 0; right: 0; bottom: 0; z-index: 2;
+  padding: 14px 0; border-bottom: 0;
+  background: color-mix(in oklab, var(--bg-2) 60%, transparent);
+  backdrop-filter: blur(8px);
+}
+.marquee--hero .marquee__track { gap: 26px; }
+.marquee--hero .marquee__track span { font-family: var(--font-mono); font-style: normal; font-size: 12.5px; letter-spacing: 0.04em; color: var(--text-dim); }
+.marquee--hero .marquee__dot { font-size: 11px !important; }
 
 /* ---------- Work ---------- */
 .work__grid { display: grid; grid-template-columns: repeat(2, 1fr); gap: clamp(28px, 4vw, 56px); }
@@ -442,19 +459,21 @@ main, .footer, .nav { position: relative; z-index: 1; }
 .tw__sw:hover { transform: scale(1.12); }
 .tw__sw.active { border-color: var(--text); }
 
-/* ---------- Split hero (Photo Hero variant) ---------- */
+/* ---------- Split hero (orbiting-SSD variant) ---------- */
 .shero {
-  max-width: var(--maxw); margin: 0 auto; min-height: 100svh;
-  display: grid; grid-template-columns: 1.05fr 0.95fr; gap: clamp(36px, 5vw, 80px);
-  align-items: center; padding: 132px var(--pad) 80px;
+  position: relative;
+  max-width: 100%; margin: 0 auto; min-height: 100svh; overflow-x: clip;
+  display: grid; grid-template-columns: minmax(0, 0.85fr) minmax(0, 1.15fr); gap: clamp(28px, 5vw, 96px);
+  align-items: center; padding: 124px clamp(28px, 6vw, 110px) 104px;
 }
 .shero__slogan {
-  display: inline-flex; align-items: center; gap: 9px;
+  display: inline-flex; align-items: center; gap: 9px; white-space: nowrap;
   font-family: var(--font-mono); font-size: 11.5px; letter-spacing: 0.05em; text-transform: uppercase;
   color: var(--text-dim); border: 1px solid var(--line);
   background: color-mix(in oklab, var(--surface) 60%, transparent);
   padding: 7px 14px; border-radius: 100px; margin-bottom: 30px;
 }
+.shero__slogan-em { color: var(--text); font-weight: 700; }
 .shero__title {
   font-family: var(--font-display); font-weight: 400;
   font-size: clamp(44px, 6vw, 88px); line-height: 0.98; letter-spacing: -0.03em; margin-bottom: 26px;
@@ -467,40 +486,117 @@ main, .footer, .nav { position: relative; z-index: 1; }
 .shero__contact { display: flex; flex-wrap: wrap; gap: clamp(22px, 4vw, 52px); padding-top: 28px; border-top: 1px solid var(--line); }
 .shero__contact dt { font-family: var(--font-mono); font-size: 10px; text-transform: uppercase; letter-spacing: 0.1em; color: var(--text-faint); margin-bottom: 6px; }
 .shero__contact dd { font-size: 14.5px; color: var(--text); font-weight: 450; }
-.shero__stack { margin-top: 22px; }
-.shero__stack-k { display: block; font-family: var(--font-mono); font-size: 10px; text-transform: uppercase; letter-spacing: 0.1em; color: var(--text-faint); margin-bottom: 11px; }
-.shero__chips { list-style: none; display: flex; flex-wrap: wrap; gap: 8px; }
-.shero__chips li { font-size: 12.5px; font-weight: 450; color: var(--text); padding: 5px 12px; border: 1px solid var(--line); border-radius: 100px; background: color-mix(in oklab, var(--surface) 50%, transparent); transition: border-color .25s, color .25s; }
-.shero__chips li:first-child, .shero__chips li:nth-child(2) { border-color: color-mix(in oklab, var(--accent) 45%, var(--line)); color: var(--accent); }
-
-.shero__media { position: relative; height: clamp(460px, 78svh, 740px); }
-.shero__media::before {
-  content: ""; position: absolute; inset: -8% -10% -4% -6%; z-index: 0; border-radius: 40px;
-  background: radial-gradient(60% 60% at 70% 25%, oklch(var(--accent-l) var(--accent-c) var(--accent-h) / 0.35), transparent 70%);
-  filter: blur(40px);
-}
-.shero__frame {
-  position: relative; z-index: 1; height: 100%; border-radius: 24px; overflow: hidden;
-  border: 1px solid var(--line); box-shadow: 0 40px 90px -45px rgba(0,0,0,0.6);
-}
-.shero__frame image-slot { display: block; }
-.shero__badge {
-  position: absolute; z-index: 2; left: 16px; bottom: 16px;
-  display: inline-flex; align-items: center; gap: 8px;
-  font-family: var(--font-mono); font-size: 11.5px; color: var(--text);
-  background: color-mix(in oklab, var(--bg) 76%, transparent); backdrop-filter: blur(10px);
-  border: 1px solid var(--line); padding: 8px 13px; border-radius: 100px;
-}
-.shero__tag {
-  position: absolute; z-index: 2; right: 16px; top: 16px;
-  font-family: var(--font-mono); font-size: 10.5px; letter-spacing: 0.1em; color: var(--text);
-  background: color-mix(in oklab, var(--bg) 70%, transparent); backdrop-filter: blur(10px);
-  border: 1px solid var(--line); padding: 6px 11px; border-radius: 8px;
-}
 .shero .reveal { transition-delay: calc(var(--d, 0) * 90ms); }
+
+/* ---------- Orbital SSD scene ---------- */
+.hero3d {
+  position: relative; align-self: center; justify-self: center;
+  width: 100%; min-height: clamp(440px, 70svh, 640px);
+  display: grid; place-items: center; perspective: 1100px;
+  overflow: visible;
+}
+.hero3d__glow {
+  position: absolute; width: 46%; height: 40%; border-radius: 50%;
+  background: radial-gradient(circle, color-mix(in oklab, var(--accent) 55%, transparent), transparent 70%);
+  filter: blur(52px); opacity: 0.55; z-index: 0;
+}
+.orbit-system {
+  --scale: 1;
+  position: relative; width: 540px; height: 380px;
+  transform: scale(var(--scale)); z-index: 1;
+}
+/* orbit rings (tilted ellipses) */
+.orbit-ring {
+  position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%);
+  border: 1px dashed; border-radius: 50%; opacity: 0.4;
+}
+.orbit-ring--lang { width: 192px; height: 86px; border-color: var(--g-lang); }
+.orbit-ring--fw   { width: 270px; height: 120px; border-color: var(--g-fw); }
+.orbit-ring--inf  { width: 348px; height: 154px; border-color: var(--g-inf); }
+.orbit-ring--ml   { width: 432px; height: 190px; border-color: var(--g-ml); }
+.orbit-ring--std  { width: 516px; height: 226px; border-color: var(--g-std); }
+
+/* realistic enterprise SSD */
+.ssd {
+  position: absolute; top: 50%; left: 50%; width: 158px; height: 116px;
+  margin: -58px 0 0 -79px; z-index: 50;
+  transform-style: preserve-3d; animation: ssdRock 11s ease-in-out infinite;
+  backface-visibility: hidden;
+}
+.ssd__label, .ssd__label * { -webkit-font-smoothing: antialiased; text-rendering: geometricPrecision; }
+.ssd__case {
+  position: absolute; inset: 0; border-radius: 9px; overflow: hidden;
+  background:
+    linear-gradient(125deg, rgba(255,255,255,0.22), transparent 30%),
+    linear-gradient(180deg, #3a3d42 0%, #25282c 12%, #1b1d21 100%);
+  border: 1px solid rgba(255,255,255,0.16);
+  box-shadow:
+    0 26px 50px -18px rgba(0,0,0,0.75),
+    inset 0 1px 0 rgba(255,255,255,0.3),
+    inset 0 -16px 30px rgba(0,0,0,0.55);
+}
+.ssd__screw { position: absolute; width: 8px; height: 8px; border-radius: 50%;
+  background: radial-gradient(circle at 35% 30%, #4a4d52, #161719);
+  box-shadow: inset 0 1px 1px rgba(255,255,255,0.25), 0 1px 1px rgba(0,0,0,0.6); }
+.ssd__screw--tl { top: 8px; left: 8px; }
+.ssd__screw--tr { top: 8px; right: 8px; }
+.ssd__screw--bl { bottom: 8px; left: 8px; }
+.ssd__screw--br { bottom: 8px; right: 8px; }
+.ssd__label {
+  position: absolute; inset: 16px 20px; border-radius: 4px;
+  background: linear-gradient(160deg, #fbfbf9, #ebebe6);
+  box-shadow: inset 0 0 0 1px rgba(0,0,0,0.08), 0 1px 2px rgba(0,0,0,0.25);
+  padding: 7px 9px; display: flex; flex-direction: column;
+  font-family: var(--font-sans); color: #1a1a1a; overflow: hidden;
+}
+.ssd__top { display: flex; align-items: baseline; justify-content: space-between; }
+.ssd__brand { font-weight: 800; font-size: 13px; letter-spacing: -0.01em; color: #E4002B; line-height: 1; }
+.ssd__tier { font-size: 6.5px; font-weight: 700; letter-spacing: 0.12em; text-transform: uppercase; color: #6a6a6a; }
+.ssd__model { font-family: var(--font-mono); font-size: 6.5px; letter-spacing: 0.02em; color: #555; margin-top: 3px; }
+.ssd__cap { font-family: var(--font-display); font-size: 19px; color: #111; line-height: 1; margin-top: auto; }
+.ssd__cap b { font-weight: 600; }
+.ssd__cap span { font-size: 8px; color: #666; margin-left: 1px; }
+.ssd__barcode { height: 12px; margin-top: 5px;
+  background: repeating-linear-gradient(90deg, #1a1a1a 0 1px, transparent 1px 2px, #1a1a1a 2px 4px, transparent 4px 5px, #1a1a1a 5px 6px, transparent 6px 8px); }
+.ssd__meta { display: flex; justify-content: space-between; font-family: var(--font-mono); font-size: 5.6px; letter-spacing: 0.02em; color: #777; margin-top: 3px; }
+.ssd__shine { position: absolute; inset: 0; border-radius: 9px; pointer-events: none;
+  background: linear-gradient(115deg, rgba(255,255,255,0.16) 0 18%, transparent 38%); }
+
+/* orbiting satellites */
+.sat {
+  position: absolute; top: 50%; left: 50%; will-change: transform;
+  display: inline-flex; align-items: center; gap: 6px; white-space: nowrap;
+  font-family: var(--font-sans); font-size: 11.5px; font-weight: 500; color: var(--text);
+  padding: 6px 12px 6px 10px; border-radius: 100px;
+  background: color-mix(in oklab, var(--surface) 90%, transparent);
+  border: 1px solid var(--sat-c); backdrop-filter: blur(7px);
+  box-shadow: 0 10px 22px -12px rgba(0,0,0,0.55), inset 0 1px 0 rgba(255,255,255,0.14);
+}
+.sat::before { content: ""; width: 7px; height: 7px; border-radius: 50%; background: var(--sat-c); box-shadow: 0 0 8px var(--sat-c); flex: none; }
+.sat--lang { --sat-c: var(--g-lang); }
+.sat--fw   { --sat-c: var(--g-fw); }
+.sat--inf  { --sat-c: var(--g-inf); }
+.sat--ml   { --sat-c: var(--g-ml); }
+.sat--std  { --sat-c: var(--g-std); }
+
+@keyframes ssdRock {
+  0%, 100% { transform: rotateY(-13deg) rotateX(3deg); }
+  50%      { transform: rotateY(13deg) rotateX(-1deg); }
+}
+
+/* legend */
+.orbit-legend {
+  position: absolute; bottom: 0; left: 50%; transform: translateX(-50%);
+  display: flex; flex-wrap: wrap; justify-content: center; gap: 8px 16px; z-index: 3; list-style: none;
+  font-family: var(--font-mono); font-size: 10.5px; letter-spacing: 0.04em; color: var(--text-dim);
+}
+.orbit-legend li { display: inline-flex; align-items: center; gap: 6px; }
+.orbit-legend i { width: 8px; height: 8px; border-radius: 50%; background: var(--lg); box-shadow: 0 0 6px var(--lg); }
+
+@media (prefers-reduced-motion: reduce) { .ssd { animation: none; transform: rotateY(-16deg); } }
 @media (max-width: 880px) {
   .shero { grid-template-columns: 1fr; gap: 40px; padding-top: 116px; }
-  .shero__media { height: clamp(400px, 62svh, 580px); order: -1; }
+  .hero3d { min-height: 400px; order: 1; }
 }
 
 /* ---------- App Store ---------- */
@@ -652,5 +748,4 @@ main, .footer, .nav { position: relative; z-index: 1; }
 }
 @media (max-width: 360px) {
   .skills { grid-template-columns: 1fr; }
-  .shero__chips li { font-size: 12px; }
 }

--- a/components/sections/Hero.tsx
+++ b/components/sections/Hero.tsx
@@ -1,14 +1,16 @@
 import { hero } from "@/lib/content";
 import { Reveal } from "../Reveal";
+import { HeroOrbit } from "./HeroOrbit";
+import { Marquee } from "./Marquee";
 
-/** Split-screen "Photo Hero": copy on the left, framed photo slot on the right. */
+/** Full-bleed hero: copy on the left, 3D orbiting SSD on the right, marquee pinned to the bottom. */
 export function Hero() {
   return (
     <section className="shero" id="hero">
       <div className="shero__text">
         <Reveal as="p" className="shero__slogan" d={0}>
           <span className="status__dot"></span>
-          {hero.slogan}
+          Staff Engineer @ <strong className="shero__slogan-em">SanDisk</strong>
         </Reveal>
         <h1 className="shero__title">
           <Reveal as="span" d={1}>
@@ -42,31 +44,13 @@ export function Hero() {
             </div>
           ))}
         </Reveal>
-        <Reveal as="div" className="shero__stack" d={6}>
-          <span className="shero__stack-k">{hero.stackLabel}</span>
-          <ul className="shero__chips">
-            {hero.stack.map((s) => (
-              <li key={s}>{s}</li>
-            ))}
-          </ul>
-        </Reveal>
       </div>
-      <Reveal as="div" className="shero__media" d={2}>
-        <div className="shero__frame">
-          <image-slot
-            id="hero-portrait"
-            style={{ width: "100%", height: "100%" }}
-            shape="rounded"
-            radius="20"
-            placeholder="Drop your photo here"
-          ></image-slot>
-        </div>
-        <span className="shero__badge">
-          <span className="status__dot"></span>
-          {hero.badge}
-        </span>
-        <span className="shero__tag">{hero.tag}</span>
+
+      <Reveal as="div" className="hero3d" d={3} ariaHidden>
+        <HeroOrbit />
       </Reveal>
+
+      <Marquee variant="hero" />
     </section>
   );
 }

--- a/components/sections/HeroOrbit.tsx
+++ b/components/sections/HeroOrbit.tsx
@@ -1,0 +1,73 @@
+import { heroOrbit } from "@/lib/content";
+
+/**
+ * The hero's right column: a 3D SanDisk SSD ("planet") with the tech stack as
+ * satellites orbiting it on tilted elliptical rings. Static markup only — the
+ * orbital motion + auto-fit scaling are driven by the vendored
+ * public/hero-orbit.js, which targets #orbitSystem, the .sat[data-r/-a/-s]
+ * spans, and the --scale custom property. IDs/classes must match it exactly.
+ *
+ * Rendered inside the `.hero3d` Reveal wrapper in Hero.tsx.
+ */
+export function HeroOrbit() {
+  const { ssd, satellites, legend } = heroOrbit;
+  return (
+    <>
+      <div className="hero3d__glow"></div>
+      <div className="orbit-system" id="orbitSystem">
+        <div className="orbit-ring orbit-ring--lang"></div>
+        <div className="orbit-ring orbit-ring--fw"></div>
+        <div className="orbit-ring orbit-ring--inf"></div>
+        <div className="orbit-ring orbit-ring--ml"></div>
+        <div className="orbit-ring orbit-ring--std"></div>
+
+        <div className="ssd">
+          <div className="ssd__case">
+            <span className="ssd__screw ssd__screw--tl"></span>
+            <span className="ssd__screw ssd__screw--tr"></span>
+            <span className="ssd__screw ssd__screw--bl"></span>
+            <span className="ssd__screw ssd__screw--br"></span>
+            <div className="ssd__label">
+              <div className="ssd__top">
+                <span className="ssd__brand">{ssd.brand}</span>
+                <span className="ssd__tier">{ssd.tier}</span>
+              </div>
+              <div className="ssd__model">{ssd.model}</div>
+              <div className="ssd__cap">
+                <b>{ssd.cap.value}</b>
+                <span>{ssd.cap.unit}</span>
+              </div>
+              <div className="ssd__barcode"></div>
+              <div className="ssd__meta">
+                {ssd.meta.map((m) => (
+                  <span key={m}>{m}</span>
+                ))}
+              </div>
+            </div>
+            <div className="ssd__shine"></div>
+          </div>
+        </div>
+
+        {satellites.map((sat, i) => (
+          <span
+            key={`${sat.label}-${i}`}
+            className={`sat sat--${sat.group}`}
+            data-r={sat.r}
+            data-a={sat.a}
+            data-s={sat.s}
+          >
+            {sat.label}
+          </span>
+        ))}
+      </div>
+      <ul className="orbit-legend">
+        {legend.map((l) => (
+          <li key={l.group} style={{ "--lg": `var(--g-${l.group})` }}>
+            <i></i>
+            {l.label}
+          </li>
+        ))}
+      </ul>
+    </>
+  );
+}

--- a/components/sections/Marquee.tsx
+++ b/components/sections/Marquee.tsx
@@ -1,11 +1,15 @@
 import { Fragment } from "react";
 import { marquee } from "@/lib/content";
 
-/** Infinite scrolling marquee of focus areas (CSS keyframe loop, duplicated for seamlessness). */
-export function Marquee() {
+/**
+ * Infinite scrolling marquee of focus areas (CSS keyframe loop, duplicated for
+ * seamlessness). `variant="hero"` pins it to the bottom edge of the hero
+ * section (full-bleed, mono type) instead of standing as its own band.
+ */
+export function Marquee({ variant }: { variant?: "hero" }) {
   const items = [...marquee, ...marquee];
   return (
-    <div className="marquee" aria-hidden="true">
+    <div className={`marquee${variant === "hero" ? " marquee--hero" : ""}`} aria-hidden="true">
       <div className="marquee__track">
         {items.map((label, i) => (
           <Fragment key={i}>

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -15,6 +15,7 @@ const eslintConfig = defineConfig([
     // Vendored prototype scripts, ported verbatim from Claude Design.
     "public/bg3d.js",
     "public/image-slot.js",
+    "public/hero-orbit.js",
     // Vendored PDF runtime assets (pdf.js worker, qpdf-wasm glue).
     "public/pdf-editor/**",
   ]),

--- a/lib/content.ts
+++ b/lib/content.ts
@@ -28,19 +28,51 @@ export const hero = {
     { label: "View selected work", href: "#work", arrow: "→", variant: "primary" as const },
     { label: "Download résumé", href: "/resume.pdf", arrow: "↓", variant: "ghost" as const, download: true },
   ],
-  meta: [
-    { dt: "Based in", dd: "Milpitas, California · USA" },
-    { dt: "Focus", dd: "Storage · Firmware · AI" },
-  ],
-  stackLabel: "Core stack",
-  stack: ["Python", "NVMe Datacenter SSDs", "LangChain", "LangGraph", "CrewAI", "LlamaIndex", "Llama Factory"],
-  badge: "Open to senior & staff roles",
-  tag: "PS — 2026",
+  // Location now lives in the Contact section; only Focus shows in the hero strip.
+  meta: [{ dt: "Focus", dd: "Datacenter NVMe SSDs · Python · AI Apps / AI Infra" }],
 };
+
+/**
+ * The hero's right column: a 3D SanDisk SSD with the tech stack as satellites
+ * orbiting it. Labels are copy; the orbital geometry (r/a/s) and group color
+ * keys are design parameters, copied verbatim from the prototype markup and
+ * consumed by both HeroOrbit.tsx and public/hero-orbit.js.
+ */
+export const heroOrbit = {
+  ssd: {
+    brand: "SanDisk",
+    tier: "Datacenter",
+    model: "NVMe™ SSD · SN864 · U.2",
+    cap: { value: "512", unit: "TB" },
+    meta: ["PCIe 5.0 ×4", "SN PS·2026"],
+  },
+  // group → ring class suffix (--lang/--fw/--inf/--ml/--std) drives ring + dot color
+  satellites: [
+    { label: "Python", group: "lang", r: 96, a: 40, s: 0.42 },
+    { label: "LangChain", group: "fw", r: 135, a: 20, s: 0.34 },
+    { label: "LangGraph", group: "fw", r: 135, a: 200, s: 0.34 },
+    { label: "Ollama", group: "inf", r: 174, a: 115, s: 0.28 },
+    { label: "llama.cpp", group: "inf", r: 174, a: 295, s: 0.28 },
+    { label: "LlamaIndex", group: "ml", r: 214, a: 0, s: 0.22 },
+    { label: "Llama Factory", group: "ml", r: 214, a: 90, s: 0.22 },
+    { label: "PyTorch", group: "ml", r: 214, a: 180, s: 0.22 },
+    { label: "TensorFlow", group: "ml", r: 214, a: 270, s: 0.22 },
+    { label: "NVMe", group: "std", r: 256, a: 30, s: 0.17 },
+    { label: "PCIe", group: "std", r: 256, a: 150, s: 0.17 },
+    { label: "OCP", group: "std", r: 256, a: 270, s: 0.17 },
+  ],
+  legend: [
+    { group: "lang", label: "Language" },
+    { group: "fw", label: "Frameworks" },
+    { group: "inf", label: "Inference" },
+    { group: "ml", label: "RAG & Training" },
+    { group: "std", label: "Standards" },
+  ],
+} as const;
 
 export const marquee = [
   "NVMe Datacenter SSDs",
-  "Firmware Verification",
+  "Firmware Verification (and validation)",
   "AI Infrastructure",
   "AI Applications",
   "Multi-Agent Systems",

--- a/public/hero-orbit.js
+++ b/public/hero-orbit.js
@@ -1,0 +1,68 @@
+/* ============================================================
+   hero-orbit.js — satellites orbiting the SSD ("planets around Earth")
+   Manual 3D: elliptical tilted orbits, depth → scale/opacity/z-index.
+   ============================================================ */
+(function () {
+  "use strict";
+  var sys = document.getElementById("orbitSystem");
+  if (!sys) return;
+
+  var reduce = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+  var TILT = Math.sin(28 * Math.PI / 180);   // vertical squash of the orbit ellipse
+  var sats = Array.prototype.slice.call(sys.querySelectorAll(".sat"));
+
+  sats.forEach(function (el) {
+    el._r = parseFloat(el.dataset.r) || 120;
+    el._a = (parseFloat(el.dataset.a) || 0) * Math.PI / 180;
+    el._s = parseFloat(el.dataset.s) || 0.3;
+  });
+
+  function place(el, ang) {
+    var x = el._r * Math.cos(ang);
+    var f = el._r * Math.sin(ang);          // in-plane forward component
+    var y = f * TILT;                        // screen vertical
+    var t = (f + el._r) / (2 * el._r);       // 0 (far/back) .. 1 (near/front)
+    var scale = 0.72 + t * 0.46;
+    var op = 0.5 + t * 0.5;
+    el.style.transform =
+      "translate(-50%,-50%) translate(" + x.toFixed(1) + "px," + y.toFixed(1) + "px) scale(" + scale.toFixed(3) + ")";
+    el.style.opacity = op.toFixed(3);
+    el.style.zIndex = f >= 0 ? 80 : 20;      // front of / behind the drive
+  }
+
+  if (reduce) { sats.forEach(function (el) { place(el, el._a); }); }
+  else {
+    var last = performance.now();
+    (function frame(now) {
+      var dt = (now - last) / 1000; last = now;
+      if (!document.hidden) {
+        for (var i = 0; i < sats.length; i++) {
+          sats[i]._a += sats[i]._s * dt;
+          place(sats[i], sats[i]._a);
+        }
+      }
+      requestAnimationFrame(frame);
+    })(performance.now());
+  }
+
+  /* fit the orbit to the room actually available: measure the orbit centre and
+     scale so the outermost satellite labels never cross either viewport edge */
+  var host = sys.parentElement;            // .hero3d
+  var maxR = sats.reduce(function (m, el) { return Math.max(m, el._r); }, 0);
+  function fit() {
+    var prev = sys.style.getPropertyValue("--scale");
+    sys.style.setProperty("--scale", "1");           // measure unscaled
+    var box = sys.getBoundingClientRect();
+    var cx = box.left + box.width / 2;
+    var badgeHalf = sats.reduce(function (m, el) { return Math.max(m, el.offsetWidth); }, 0) / 2;
+    var halfExtent = maxR + badgeHalf;               // px from centre at scale 1
+    var vw = document.documentElement.clientWidth;
+    var margin = 14;
+    var room = Math.min(cx - margin, vw - cx - margin);   // nearer edge wins
+    var s = room / halfExtent;
+    s = Math.max(0.42, Math.min(1.4, s));
+    sys.style.setProperty("--scale", s ? s.toFixed(3) : (prev || "1"));
+  }
+  fit();
+  window.addEventListener("resize", fit, { passive: true });
+})();


### PR DESCRIPTION
Ports the re-exported Claude Design hero into the Next.js app, plus a docs refresh.

## Hero redesign
- Replaces the right-side photo slot with a **3D SanDisk NVMe SSD** (512 TB · SN864 · U.2) and the tech stack as **color-grouped satellites orbiting it** on 5 tilted rings (Language / Frameworks / Inference / RAG & Training / Standards), with a legend.
- **Full-bleed hero** layout (text left, orbit right); **marquee pinned to the hero's bottom** (mono 12.5px).
- Hero meta is now Focus-only ("Datacenter NVMe SSDs · Python · AI Apps / AI Infra") — location stays in Contact. Marquee reads "Firmware Verification (and validation)".
- Vendored `public/hero-orbit.js` (orbit animation + auto-fit scaling), loaded via `next/script` like `bg3d.js`; orbit data lives in `lib/content.ts` (`heroOrbit`).

## Docs
- Expanded `CLAUDE.md` with commands + big-picture architecture.
- Refreshed `README.md` structure for the `(site)`/`(tool)` route groups.

## Audit
A full rule-level diff of the re-exported `styles.css` vs the live site confirmed the **hero was the only changed section**. Kept the existing **light + grain-on** defaults (did not adopt the export's dark/grain-off saved state).

## Verification
- `npm run lint` — 0 errors · `npm run build` — succeeds
- Browser-driven: orbit animates with depth, auto-scales (1.32× desktop / 0.55× mobile), **no horizontal overflow**, console clean, legible in **light and dark**, stacks single-column on mobile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)